### PR TITLE
Prepare beSwarm site for launch.

### DIFF
--- a/components/becampSponsors.vue
+++ b/components/becampSponsors.vue
@@ -43,11 +43,11 @@
     </div>
     <div class="sponsor-tier become-a-sponsor">
       <div class="cta">
-        <h2>Want to become a beSwarm sponsor?</h2>
-        <p>We're always in need of an extra helping hand.</p>
+        <h2>Want to become a beCamp/beSwarm sponsor?</h2>
+        <p>Our conferences happen because of you.</p>
         <a
-          href="mailto:todd.gerdy@gmail.com?subject=beCamp Sponsorship&body=Hello! I'd like to learn more about becoming a sponsor for beCamp!"
-          name="Email beCamp organizer"
+          href="mailto:ron.duplain@gmail.com?subject=beCamp/beSwarm Sponsorship&body=Hello! I'd like to learn more about becoming a sponsor for beCamp/beSwarm!"
+          name="Email beCamp/beSwarm organizer"
         >
           <button>Become a Sponsor</button>
         </a>

--- a/components/newsletterSignup.vue
+++ b/components/newsletterSignup.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="page-section newsletter-signup-form">
     <h2>Join the beCamp newsletter!</h2>
-    <h4 class="light">Get the latest news and notifications about beCamp</h4>
+    <h4 class="light">Get the latest news and notifications about beCamp/beSwarm.</h4>
     <div id="mc_embed_signup">
       <form action="https://becamp.us15.list-manage.com/subscribe/post?u=f75f5915da9ca3ce7be9baad3&amp;id=91e20a1da0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="newsletter-form" target="_blank">
         <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>

--- a/libs/api.js
+++ b/libs/api.js
@@ -28,7 +28,11 @@ class Api {
       endpointUrl: 'https://api.airtable.com',
       apiKey: process.env.airtableKey
     })
-    this.airtable = Airtable.base('apptQ2PByq7vFJlxR')
+    // Access the generated Airtable API docs for the base, and note the URL:
+    // https://airtable.com/<key>/api/docs
+    //
+    // Use this <key> as the string argument to Airtable.base('...').
+    this.airtable = Airtable.base('applj3FozCmao4YiE') // beSwarm 2019
     Vue.prototype.$api = this
   }
 

--- a/pages/swarm/index.vue
+++ b/pages/swarm/index.vue
@@ -96,6 +96,13 @@
       </div>
     </section>
 
+    <section class="page-section tac save-the-date">
+      <div class="wysiwyg-block">
+        <h1 class="section-title small-margin">Save the Date!</h1>
+        <div v-html="page.save_the_date"></div>
+      </div>
+    </section>
+
     <section
       v-if="Object.keys(directoryAttendees).length > 10"
       class="page-section full decorative-bg"

--- a/pages/swarm/index.vue
+++ b/pages/swarm/index.vue
@@ -67,7 +67,7 @@
           :href="`https://www.youtube.com/watch?v=${page.homepage_hero_video_youtube_id}`"
           target="_blank" rel="noopener"
         >
-          <button>What is beSwarm? (Video)</button>
+          <button>What is beCamp? (Video)</button>
         </a>
       </div>
     </section>
@@ -83,7 +83,7 @@
         <h2>Let us know you're attending!</h2>
         <p>It's quick and easy, and helps us order the correct amout of food.</p>
         <a
-          href="#"
+          href="https://airtable.com/shr9e89GaGsECwTyO"
           target="_blank"
           rel="noopener"
           name="beCamp registration link"

--- a/pages/swarm/index.vue
+++ b/pages/swarm/index.vue
@@ -97,7 +97,7 @@
     </section>
 
     <section
-      v-if="Object.keys(directoryAttendees).length > 18"
+      v-if="Object.keys(directoryAttendees).length > 10"
       class="page-section full decorative-bg"
     >
       <div class="wysiwyg-block">

--- a/pages/swarm/index.vue
+++ b/pages/swarm/index.vue
@@ -14,6 +14,7 @@
       <div class="inner">
         <div class="event-headline">
           <div v-html="setAttendeeCount(page.homepage_hero_content)"></div>
+          <!-- Wondering where this is? Go to "Guests" in the forked Airtable Base and change the "Grid view" to the form's view. -->
           <a
             href="https://airtable.com/shr9e89GaGsECwTyO"
             target="_blank" rel="noopener"
@@ -82,6 +83,7 @@
       <div class="cta">
         <h2>Let us know you're attending!</h2>
         <p>It's quick and easy, and helps us order the correct amout of food.</p>
+        <!-- See comment above on Airtable. -->
         <a
           href="https://airtable.com/shr9e89GaGsECwTyO"
           target="_blank"

--- a/store/index.js
+++ b/store/index.js
@@ -146,7 +146,7 @@ export const actions = {
   getSchedule({commit}) {
     return new Promise((resolve, reject) => {
       let base = this.app.api.airtable
-      base('2018 Saturday Schedule').select({
+      base('Dummy Schedule').select({
         maxRecords: 999,
         view: "Grid view"
       }).eachPage(function page(records, fetchNextPage) {
@@ -201,7 +201,7 @@ export const mutations = {
       logo: payload['Logo'],
       url: payload['Url'],
       write_up: payload['Write up'],
-      level: payload['2018 Sponsorship Level']
+      level: payload['2019 Swarm Sponsorship Level']
     })
   },
   setAttendee(state, payload) {


### PR DESCRIPTION
This pull request prepares be.camp for launch with info and RSVPs for beSwarm 2019.

We are getting clearer on the beCamp/beSwarm branding and messaging. However, I'm following the directive of minimal changes to the beCamp site to support beSwarm. Accordingly, various identifiers will still be `becamp` while the copy is updated to match "beSwarm" or "beCamp/beSwarm."

Further playing into the beSwarm-beCamp dynamic, I added a quick "Save the Date!" section to further inform the core community. This could use some graphics and call to action on the newsletter. I kept it very simple for now.

Separately, the error message from Nuxt.js is completely unusable when you get the Airtable key wrong. (It tells you about `err.message` with message undefined and no additional stack frames.) I added a comment to help avoid that in the future.